### PR TITLE
fix(hvac): Assign always available schedule to template HVAC

### DIFF
--- a/honeybee_openstudio/simulation.py
+++ b/honeybee_openstudio/simulation.py
@@ -228,7 +228,7 @@ def run_period_to_openstudio(run_period, os_model):
     return os_run_period
 
 
-def simulation_parameter_to_openstudio(sim_par, seed_model=None, epw_file=None):
+def simulation_parameter_to_openstudio(sim_par, seed_model=None):
     """Convert Honeybee SimulationParameter to an OpenStudio model.
 
     Args:
@@ -236,9 +236,6 @@ def simulation_parameter_to_openstudio(sim_par, seed_model=None, epw_file=None):
         seed_model: An optional OpenStudio Model object to which the Honeybee
             Model will be added. If None, a new OpenStudio Model will be
             initialized within this method. (Default: None).
-        epw_file: An optional path to an EPW file to be assigned to the OpenStudio
-            model and will be used to assign criteria like the ASHRAE climate zone
-            to the Model. (Default: None).
     """
     # create the OpenStudio model object
     os_model = OSModel() if seed_model is None else seed_model

--- a/honeybee_openstudio/writer.py
+++ b/honeybee_openstudio/writer.py
@@ -564,7 +564,7 @@ def model_to_openstudio(
             presence of Rooms in the Model, which is as necessary prerequisite
             for simulation in EnergyPlus. (Default: False).
         print_progress: Set to True to have the progress of the translation
-            printed as it is completed.
+            printed as it is completed. (Default: False).
 
     Usage:
 
@@ -622,6 +622,10 @@ def model_to_openstudio(
     rem_msgs = model.properties.energy.remove_hvac_from_no_setpoints()
     if len(rem_msgs) != 0:
         print('\n'.join(rem_msgs))
+
+    # auto-assign stories if there are none since most OpenStudio measures need these
+    if len(model.stories) == 0 and len(model.rooms) != 0:
+        model.assign_stories_by_floor_height()
 
     # reset the IDs to be derived from the display_names if requested
     if use_geometry_names:


### PR DESCRIPTION
This was needed as openstudio-standards tries to come up with its own availability schedule only for VAV systems (not for DOAS systems), which is often overly-optimistic and assumes the building is unoccupied when occupancy drops below 15%.

Assigning an "Always Available" schedule stops this behavior in openstudio-standards when the efficiencies area applied. In the future, we will expose some way for users to assign a vent_availability_schedule to All-Air systems so that they can specify controls for building occupancy if they want.